### PR TITLE
feat: adopt the board scale map (scale_fill/colour_manual from scale_map)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blockr.ggplot
 Title: Interactive 'ggplot2' Visualization Blocks
-Version: 0.1.0
+Version: 0.1.1
 Authors@R:
     c(person(given = "Christoph",
              family = "Sax",
@@ -49,6 +49,7 @@ Imports:
     shinyjs,
     shinyWidgets
 Suggests:
+    blockr.theme,
     cowplot,
     ggpubr,
     ggthemes,

--- a/R/ggplot-block.R
+++ b/R/ggplot-block.R
@@ -691,6 +691,26 @@ new_ggplot_block <- function(
                 text <- glue::glue("({text}) + ggplot2::theme_minimal()")
               }
 
+              # Board scale map (blockr.theme via Suggests): inject manual
+              # scales for bound discrete variables so the same level shows
+              # the same color as in every other consumer. Pie maps fill
+              # from x when no fill aesthetic is set (mirrors aes assembly
+              # above). NULL (no theme / no map / no complete binding) keeps
+              # ggplot defaults.
+              fill_var <- if (r_fill() != "(none)") {
+                r_fill()
+              } else if (current_type == "pie") {
+                r_x()
+              }
+              for (sm in c(
+                gg_scale_map_text(session, data(), fill_var, "fill"),
+                if (r_color() != "(none)") {
+                  gg_scale_map_text(session, data(), r_color(), "colour")
+                }
+              )) {
+                text <- glue::glue("({text}) + {sm}")
+              }
+
               parse(text = text)[[1]]
             }),
             state = list(

--- a/R/scale-map.R
+++ b/R/scale-map.R
@@ -1,0 +1,62 @@
+# Board scale-map adoption (convention: blockr.docs/patterns/scale-map.md).
+# The mechanism lives in blockr.theme, consumed behind a Suggests guard:
+# without blockr.theme, without a "scale_map" board option, or without a
+# binding for the mapped variable, plots keep ggplot's default colors.
+# ggplot `fill` consumes the `color` channel of a binding (channels are
+# semantic; there is no separate fill binding).
+
+# Build a "ggplot2::scale_*_manual(values = ...)" text fragment for `var`,
+# or NULL when nothing applies. Resolved values are injected as literals so
+# the block's expr stays a self-contained reproduction of what was shown.
+# scale_*_manual() errors on missing levels, so only a complete assignment
+# (every level resolved, e.g. pins + pool/board palette) is injected.
+gg_scale_map_text <- function(session, data, var, aesthetic) {
+  if (is.null(var) || identical(var, "(none)") || !nzchar(var)) {
+    return(NULL)
+  }
+  if (!requireNamespace("blockr.theme", quietly = TRUE)) {
+    return(NULL)
+  }
+  if (!is.data.frame(data) || !var %in% names(data)) {
+    return(NULL)
+  }
+
+  map <- tryCatch(
+    blockr.core::get_board_option_or_null("scale_map", session),
+    error = function(e) NULL
+  )
+  if (is.null(map) || !length(map)) {
+    return(NULL)
+  }
+
+  col <- data[[var]]
+  lvls <- if (is.factor(col)) {
+    levels(col)
+  } else {
+    lv <- unique(as.character(col))
+    lv[!is.na(lv)]
+  }
+  if (!length(lvls)) {
+    return(NULL)
+  }
+
+  res <- tryCatch(
+    blockr.theme::resolve_scales(map, var, levels = lvls),
+    error = function(e) NULL
+  )
+  vals <- res$color
+  if (is.null(vals) || !all(lvls %in% names(vals))) {
+    return(NULL)
+  }
+
+  fun <- switch(
+    aesthetic,
+    fill = "scale_fill_manual",
+    colour = "scale_colour_manual"
+  )
+  pairs <- paste(
+    sprintf('"%s" = "%s"', names(vals), unname(vals)),
+    collapse = ", "
+  )
+  glue::glue("ggplot2::{fun}(values = c({pairs}))")
+}

--- a/tests/testthat/test-scale-map.R
+++ b/tests/testthat/test-scale-map.R
@@ -1,0 +1,66 @@
+# Board scale-map adoption: the expr gains a literal scale_*_manual() when
+# the board option binds the mapped variable (mechanism in blockr.theme).
+
+test_that("ggplot block expr injects scale_fill_manual from the board map", {
+  skip_if_not_installed("blockr.theme")
+
+  df <- data.frame(
+    TRT = c("A", "A", "B"),
+    AVAL = c(1, 2, 3)
+  )
+  blk <- new_ggplot_block(type = "bar", x = "TRT", fill = "TRT")
+
+  shiny::testServer(
+    blockr.core:::get_s3_method("block_server", blk),
+    {
+      session$userData$board_options <- list(
+        scale_map = shiny::reactiveVal(
+          list(TRT = list(color = list(A = "#111111", B = "#222222")))
+        )
+      )
+      session$flushReact()
+      txt <- paste(deparse(session$returned$expr()), collapse = " ")
+      expect_match(txt, "scale_fill_manual", fixed = TRUE)
+      expect_match(txt, "#111111", fixed = TRUE)
+    },
+    args = list(x = blk, data = list(data = function() df))
+  )
+})
+
+test_that("no binding / no map -> no manual scale, ggplot defaults", {
+  df <- data.frame(TRT = c("A", "B"), AVAL = c(1, 2))
+  blk <- new_ggplot_block(type = "bar", x = "TRT", fill = "TRT")
+
+  shiny::testServer(
+    blockr.core:::get_s3_method("block_server", blk),
+    {
+      session$flushReact()
+      txt <- paste(deparse(session$returned$expr()), collapse = " ")
+      expect_no_match(txt, "scale_fill_manual", fixed = TRUE)
+    },
+    args = list(x = blk, data = list(data = function() df))
+  )
+})
+
+test_that("incomplete binding (unpinned level, no pool) is not injected", {
+  skip_if_not_installed("blockr.theme")
+
+  df <- data.frame(TRT = c("A", "B"), AVAL = c(1, 2))
+  blk <- new_ggplot_block(type = "bar", x = "TRT", fill = "TRT")
+
+  shiny::testServer(
+    blockr.core:::get_s3_method("block_server", blk),
+    {
+      session$userData$board_options <- list(
+        scale_map = shiny::reactiveVal(
+          list(TRT = list(color = list(A = "#111111")))
+        )
+      )
+      session$flushReact()
+      txt <- paste(deparse(session$returned$expr()), collapse = " ")
+      # scale_*_manual errors on missing levels; partial pins fall back
+      expect_no_match(txt, "scale_fill_manual", fixed = TRUE)
+    },
+    args = list(x = blk, data = list(data = function() df))
+  )
+})


### PR DESCRIPTION
Standalone change (independent of the block-arg migration / blockr.ai#86).

The ggplot expr gains literal `scale_fill_manual()` / `scale_colour_manual()`
when the `scale_map` board option binds the mapped discrete variable — same
level→color mapping as every other consumer (echarts drilldown, gantt), so
the exported code reproduces exactly what was shown. `fill` consumes the
binding's color channel per the convention (`blockr.docs/patterns/scale-map.md`).
Only complete assignments are injected (`scale_*_manual` errors on gaps); no
theme / no map / no binding keeps ggplot defaults. `blockr.theme` added via
Suggests.

This commit pre-existed on local `main` ahead of origin; surfacing it as its
own PR so it is reviewed and lands independently of the registry migration.
