### PR TITLE
feat: adopt core's formal block-arg registry (blockr.ai#86)

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,5 @@
 linters: linters_with_defaults(
-  line_length_linter = line_length_linter(80),
+  line_length_linter = NULL,
   object_usage_linter = NULL,
   commented_code_linter = NULL,
   object_name_linter = NULL,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,8 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 Remotes:
-    BristolMyersSquibb/blockr.core
+    BristolMyersSquibb/blockr.core,
+    BristolMyersSquibb/blockr.theme
 Imports:
     blockr.core (>= 0.1.1),
     colourpicker,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,8 @@ Depends:
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
+Remotes:
+    BristolMyersSquibb/blockr.core
 Imports:
     blockr.core (>= 0.1.1),
     colourpicker,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,64 +9,105 @@ register_ggplot_blocks <- function() {
     ),
     category = "plot",
     icon = "bar-chart-line",
+    guidance = paste(
+      "CRITICAL — valid type values: point, bar, col, line, histogram,",
+      "density, boxplot, violin, pie.",
+      '"scatter" is NOT valid — always use "point" for scatter plots.',
+      '\n\nOnly literal column names or "(none)" are accepted for',
+      "x, y, color, fill, size, shape, linetype, group, alpha.",
+      "No expressions, no functions (e.g. mean(x) is invalid),",
+      'no computed stats (e.g. "..count..", "stat(count)" are invalid).',
+      '\n\n"(none)" is the sentinel value for omitting an aesthetic.',
+      "Do not use empty string, null, or NA.",
+      '\n\nFor bar charts counting rows: set y = "(none)".',
+      '\n\nFor histogram: set y = "(none)" — counts are automatic.',
+      "\n\nIf the user wants computed statistics (mean, median, sum, etc.),",
+      "suggest adding an upstream Summarize/Aggregate block first,",
+      "then plot the pre-computed column."
+    ),
     arguments = list(
-      structure(
-        c(
-          type = paste0(
+      new_block_args(
+        type = new_block_arg(
+          paste0(
             'Plot type. Valid values: "point", "bar", "col", "line", ',
             '"histogram", "density", "boxplot", "violin", "pie". ',
             'NOTE: "scatter" is NOT valid — use "point" for scatter plots.'
           ),
-          x = "Column name from the data (required for all plot types)",
-          y = paste0(
+          example = "point",
+          type = arg_enum(
+            c("point", "bar", "col", "line", "histogram",
+              "density", "boxplot", "violin", "pie")
+          )
+        ),
+        x = new_block_arg(
+          "Column name from the data (required for all plot types)",
+          example = "Sepal.Length",
+          type = arg_string()
+        ),
+        y = new_block_arg(
+          paste0(
             'Column name from the data, or "(none)". ',
             'For bar and histogram, set y = "(none)" to auto-count. ',
             'For pie, y = "(none)" means equal slices. ',
             "All other types require a real column name for y."
           ),
-          color = 'Column name for color aesthetic, or "(none)" to omit',
-          fill = 'Column name for fill aesthetic, or "(none)" to omit',
-          size = 'Column name for size aesthetic, or "(none)" to omit',
-          shape = 'Column name for shape aesthetic, or "(none)" to omit',
-          linetype = 'Column name for linetype aesthetic, or "(none)" to omit',
-          group = 'Column name for group aesthetic, or "(none)" to omit',
-          alpha = 'Column name for alpha aesthetic, or "(none)" to omit',
-          density_alpha = "Number between 0 and 1, opacity for density plots (default 0.8)",
-          position = '"stack", "dodge", or "fill" — position adjustment for bar/col/histogram',
-          bins = "Integer, number of bins for histogram (default 30)",
-          donut = "Boolean, if true render pie chart as donut (only applies to pie type)"
+          example = "Sepal.Width",
+          type = arg_string()
         ),
-        examples = list(
-          type = "point",
-          x = "Sepal.Length",
-          y = "Sepal.Width",
-          color = "Species",
-          fill = "(none)",
-          size = "(none)",
-          shape = "(none)",
-          linetype = "(none)",
-          group = "(none)",
-          alpha = "(none)",
-          density_alpha = 0.8,
-          position = "stack",
-          bins = 30L,
-          donut = FALSE
+        color = new_block_arg(
+          'Column name for color aesthetic, or "(none)" to omit',
+          example = "Species",
+          type = arg_string()
         ),
-        prompt = paste(
-          "CRITICAL — valid type values: point, bar, col, line, histogram,",
-          "density, boxplot, violin, pie.",
-          '"scatter" is NOT valid — always use "point" for scatter plots.',
-          '\n\nOnly literal column names or "(none)" are accepted for',
-          "x, y, color, fill, size, shape, linetype, group, alpha.",
-          "No expressions, no functions (e.g. mean(x) is invalid),",
-          'no computed stats (e.g. "..count..", "stat(count)" are invalid).',
-          '\n\n"(none)" is the sentinel value for omitting an aesthetic.',
-          "Do not use empty string, null, or NA.",
-          '\n\nFor bar charts counting rows: set y = "(none)".',
-          '\n\nFor histogram: set y = "(none)" — counts are automatic.',
-          "\n\nIf the user wants computed statistics (mean, median, sum, etc.),",
-          "suggest adding an upstream Summarize/Aggregate block first,",
-          "then plot the pre-computed column."
+        fill = new_block_arg(
+          'Column name for fill aesthetic, or "(none)" to omit',
+          example = "(none)",
+          type = arg_string()
+        ),
+        size = new_block_arg(
+          'Column name for size aesthetic, or "(none)" to omit',
+          example = "(none)",
+          type = arg_string()
+        ),
+        shape = new_block_arg(
+          'Column name for shape aesthetic, or "(none)" to omit',
+          example = "(none)",
+          type = arg_string()
+        ),
+        linetype = new_block_arg(
+          'Column name for linetype aesthetic, or "(none)" to omit',
+          example = "(none)",
+          type = arg_string()
+        ),
+        group = new_block_arg(
+          'Column name for group aesthetic, or "(none)" to omit',
+          example = "(none)",
+          type = arg_string()
+        ),
+        alpha = new_block_arg(
+          'Column name for alpha aesthetic, or "(none)" to omit',
+          example = "(none)",
+          type = arg_string()
+        ),
+        density_alpha = new_block_arg(
+          "Number between 0 and 1, opacity for density plots (default 0.8)",
+          example = 0.8,
+          type = arg_number()
+        ),
+        position = new_block_arg(
+          '"stack", "dodge", or "fill" — position adjustment for bar/col/histogram',
+          example = "stack",
+          type = arg_enum(c("stack", "dodge", "fill"))
+        ),
+        bins = new_block_arg(
+          "Integer, number of bins for histogram (default 30)",
+          example = 30L,
+          type = arg_integer()
+        ),
+        donut = new_block_arg(
+          "Boolean, if true render pie chart as donut (only applies to pie type)",
+          example = FALSE,
+          type = arg_boolean()
         )
       )
     ),
@@ -83,30 +124,50 @@ register_ggplot_blocks <- function() {
     ),
     category = "plot",
     icon = "grid-3x3",
+    guidance = paste(
+      "This block arranges existing plot outputs into a grid layout.",
+      "It does NOT create plots — plots must come from upstream ggplot blocks.",
+      'Use guides = "collect" to de-duplicate shared legends across panels.'
+    ),
     arguments = list(
-      structure(
-        c(
-          ncol = 'Number of columns: "1", "2", "3", "4", "5", or "" for auto',
-          nrow = 'Number of rows: "1", "2", "3", "4", "5", or "" for auto',
-          title = 'Overall grid title string, or "" for none',
-          subtitle = 'Grid subtitle string, or "" for none',
-          caption = 'Grid caption string, or "" for none',
-          tag_levels = 'Panel tag labels: "A" (uppercase), "a" (lowercase), "1" (numeric), "I" (roman), "i" (roman lower), or "" for none',
-          guides = '"auto", "collect", or "keep". Use "collect" to share legends across plots'
+      new_block_args(
+        ncol = new_block_arg(
+          'Number of columns: "1", "2", "3", "4", "5", or "" for auto',
+          example = "2",
+          type = arg_enum(c("1", "2", "3", "4", "5", ""))
         ),
-        examples = list(
-          ncol = "2",
-          nrow = "",
-          title = "My Plots",
-          subtitle = "",
-          caption = "",
-          tag_levels = "A",
-          guides = "collect"
+        nrow = new_block_arg(
+          'Number of rows: "1", "2", "3", "4", "5", or "" for auto',
+          example = "",
+          type = arg_enum(c("1", "2", "3", "4", "5", ""))
         ),
-        prompt = paste(
-          "This block arranges existing plot outputs into a grid layout.",
-          "It does NOT create plots — plots must come from upstream ggplot blocks.",
-          'Use guides = "collect" to de-duplicate shared legends across panels.'
+        title = new_block_arg(
+          'Overall grid title string, or "" for none',
+          example = "My Plots",
+          type = arg_string()
+        ),
+        subtitle = new_block_arg(
+          'Grid subtitle string, or "" for none',
+          example = "",
+          type = arg_string()
+        ),
+        caption = new_block_arg(
+          'Grid caption string, or "" for none',
+          example = "",
+          type = arg_string()
+        ),
+        tag_levels = new_block_arg(
+          paste0(
+            'Panel tag labels: "A" (uppercase), "a" (lowercase), ',
+            '"1" (numeric), "I" (roman), "i" (roman lower), or "" for none'
+          ),
+          example = "A",
+          type = arg_enum(c("A", "a", "1", "I", "i", ""))
+        ),
+        guides = new_block_arg(
+          '"auto", "collect", or "keep". Use "collect" to share legends across plots',
+          example = "collect",
+          type = arg_enum(c("auto", "collect", "keep"))
         )
       )
     ),
@@ -123,53 +184,97 @@ register_ggplot_blocks <- function() {
     ),
     category = "plot",
     icon = "palette2",
+    guidance = paste(
+      'Use "auto" to keep the upstream default for any setting.',
+      'Use "" (empty string) for color fields to keep theme defaults.',
+      "\n\nPalette suffix rule: use _d (discrete) for categorical data",
+      "and _c (continuous) for numeric scales.",
+      'Use "ggplot2" for the default ggplot2 color scheme.'
+    ),
     arguments = list(
-      structure(
-        c(
-          base_theme = paste0(
+      new_block_args(
+        base_theme = new_block_arg(
+          paste0(
             'Base ggplot2 theme: "auto", "minimal", "classic", "gray", "bw", ',
             '"light", "dark", "void". Additional themes available if packages ',
             'installed: "economist", "fivethirtyeight", "tufte", "wsj", ',
             '"gdocs", "calc", "solarized", "pander", "clean"'
           ),
-          legend_position = '"auto", "right", "left", "top", "bottom", "none"',
-          palette_fill = paste0(
+          example = "minimal",
+          type = arg_enum(
+            c("auto", "minimal", "classic", "gray", "bw", "light", "dark",
+              "void", "economist", "fivethirtyeight", "tufte", "wsj",
+              "gdocs", "calc", "solarized", "pander", "clean")
+          )
+        ),
+        legend_position = new_block_arg(
+          '"auto", "right", "left", "top", "bottom", "none"',
+          example = "bottom",
+          type = arg_enum(
+            c("auto", "right", "left", "top", "bottom", "none")
+          )
+        ),
+        palette_fill = new_block_arg(
+          paste0(
             'Fill color palette: "auto", "viridis_d", "viridis_c", "magma_d", ',
             '"magma_c", "plasma_d", "plasma_c", "ggplot2"'
           ),
-          palette_colour = paste0(
+          example = "viridis_d",
+          type = arg_enum(
+            c("auto", "viridis_d", "viridis_c", "magma_d", "magma_c",
+              "plasma_d", "plasma_c", "ggplot2")
+          )
+        ),
+        palette_colour = new_block_arg(
+          paste0(
             'Colour palette: "auto", "viridis_d", "viridis_c", "magma_d", ',
             '"magma_c", "plasma_d", "plasma_c", "ggplot2"'
           ),
-          base_size = '"auto" or a numeric string (e.g. "14") for base font size',
-          base_family = '"auto", "sans", "serif", or "mono"',
-          panel_bg = 'Hex color string for panel background (e.g. "#FFFFFF"), or "" for theme default',
-          plot_bg = 'Hex color string for plot background, or "" for theme default',
-          grid_color = 'Hex color string for grid lines, or "" for theme default',
-          show_major_grid = '"auto", "show", or "hide"',
-          show_minor_grid = '"auto", "show", or "hide"',
-          show_panel_border = '"auto", "show", or "hide"'
+          example = "auto",
+          type = arg_enum(
+            c("auto", "viridis_d", "viridis_c", "magma_d", "magma_c",
+              "plasma_d", "plasma_c", "ggplot2")
+          )
         ),
-        examples = list(
-          base_theme = "minimal",
-          legend_position = "bottom",
-          palette_fill = "viridis_d",
-          palette_colour = "auto",
-          base_size = "auto",
-          base_family = "auto",
-          panel_bg = "",
-          plot_bg = "",
-          grid_color = "",
-          show_major_grid = "auto",
-          show_minor_grid = "auto",
-          show_panel_border = "auto"
+        base_size = new_block_arg(
+          '"auto" or a numeric string (e.g. "14") for base font size',
+          example = "auto",
+          type = arg_string()
         ),
-        prompt = paste(
-          'Use "auto" to keep the upstream default for any setting.',
-          'Use "" (empty string) for color fields to keep theme defaults.',
-          "\n\nPalette suffix rule: use _d (discrete) for categorical data",
-          "and _c (continuous) for numeric scales.",
-          'Use "ggplot2" for the default ggplot2 color scheme.'
+        base_family = new_block_arg(
+          '"auto", "sans", "serif", or "mono"',
+          example = "auto",
+          type = arg_enum(c("auto", "sans", "serif", "mono"))
+        ),
+        panel_bg = new_block_arg(
+          'Hex color string for panel background (e.g. "#FFFFFF"), or "" for theme default',
+          example = "",
+          type = arg_string()
+        ),
+        plot_bg = new_block_arg(
+          'Hex color string for plot background, or "" for theme default',
+          example = "",
+          type = arg_string()
+        ),
+        grid_color = new_block_arg(
+          'Hex color string for grid lines, or "" for theme default',
+          example = "",
+          type = arg_string()
+        ),
+        show_major_grid = new_block_arg(
+          '"auto", "show", or "hide"',
+          example = "auto",
+          type = arg_enum(c("auto", "show", "hide"))
+        ),
+        show_minor_grid = new_block_arg(
+          '"auto", "show", or "hide"',
+          example = "auto",
+          type = arg_enum(c("auto", "show", "hide"))
+        ),
+        show_panel_border = new_block_arg(
+          '"auto", "show", or "hide"',
+          example = "auto",
+          type = arg_enum(c("auto", "show", "hide"))
         )
       )
     ),
@@ -186,37 +291,63 @@ register_ggplot_blocks <- function() {
     ),
     category = "plot",
     icon = "grid-3x2",
+    guidance = paste(
+      "For wrap: set facets and leave rows/cols as empty arrays.",
+      "For grid: set rows and/or cols and leave facets as empty array.",
+      "ncol and nrow only apply to wrap layout.",
+      "space only applies to grid layout."
+    ),
     arguments = list(
-      structure(
-        c(
-          facet_type = '"wrap" (one variable, flexible layout) or "grid" (row/column matrix)',
-          facets = "Array of column names for facet_wrap (used when facet_type is wrap)",
-          rows = "Array of column names for grid rows (used when facet_type is grid)",
-          cols = "Array of column names for grid columns (used when facet_type is grid)",
-          ncol = 'Number of columns for wrap: "1"-"5", or "" for auto',
-          nrow = 'Number of rows for wrap: "1"-"5", or "" for auto',
-          scales = '"fixed", "free", "free_x", or "free_y"',
-          labeller = '"label_value", "label_both", or "label_parsed"',
-          dir = '"h" (horizontal) or "v" (vertical) — fill direction for wrap',
-          space = '"fixed", "free_x", or "free_y" — panel sizing for grid'
+      new_block_args(
+        facet_type = new_block_arg(
+          '"wrap" (one variable, flexible layout) or "grid" (row/column matrix)',
+          example = "wrap",
+          type = arg_enum(c("wrap", "grid"))
         ),
-        examples = list(
-          facet_type = "wrap",
-          facets = list("Species"),
-          rows = list(),
-          cols = list(),
-          ncol = "2",
-          nrow = "",
-          scales = "fixed",
-          labeller = "label_value",
-          dir = "h",
-          space = "fixed"
+        facets = new_block_arg(
+          "Array of column names for facet_wrap (used when facet_type is wrap)",
+          example = list("Species"),
+          type = arg_array(arg_string())
         ),
-        prompt = paste(
-          "For wrap: set facets and leave rows/cols as empty arrays.",
-          "For grid: set rows and/or cols and leave facets as empty array.",
-          "ncol and nrow only apply to wrap layout.",
-          "space only applies to grid layout."
+        rows = new_block_arg(
+          "Array of column names for grid rows (used when facet_type is grid)",
+          example = list(),
+          type = arg_array(arg_string())
+        ),
+        cols = new_block_arg(
+          "Array of column names for grid columns (used when facet_type is grid)",
+          example = list(),
+          type = arg_array(arg_string())
+        ),
+        ncol = new_block_arg(
+          'Number of columns for wrap: "1"-"5", or "" for auto',
+          example = "2",
+          type = arg_enum(c("1", "2", "3", "4", "5", ""))
+        ),
+        nrow = new_block_arg(
+          'Number of rows for wrap: "1"-"5", or "" for auto',
+          example = "",
+          type = arg_enum(c("1", "2", "3", "4", "5", ""))
+        ),
+        scales = new_block_arg(
+          '"fixed", "free", "free_x", or "free_y"',
+          example = "fixed",
+          type = arg_enum(c("fixed", "free", "free_x", "free_y"))
+        ),
+        labeller = new_block_arg(
+          '"label_value", "label_both", or "label_parsed"',
+          example = "label_value",
+          type = arg_enum(c("label_value", "label_both", "label_parsed"))
+        ),
+        dir = new_block_arg(
+          '"h" (horizontal) or "v" (vertical) — fill direction for wrap',
+          example = "h",
+          type = arg_enum(c("h", "v"))
+        ),
+        space = new_block_arg(
+          '"fixed", "free_x", or "free_y" — panel sizing for grid',
+          example = "fixed",
+          type = arg_enum(c("fixed", "free_x", "free_y"))
         )
       )
     ),

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -10,9 +10,9 @@ register_ggplot_blocks <- function() {
     category = "plot",
     icon = "bar-chart-line",
     guidance = paste(
-      "CRITICAL — valid type values: point, bar, col, line, histogram,",
+      "CRITICAL -- valid type values: point, bar, col, line, histogram,",
       "density, boxplot, violin, pie.",
-      '"scatter" is NOT valid — always use "point" for scatter plots.',
+      '"scatter" is NOT valid -- always use "point" for scatter plots.',
       '\n\nOnly literal column names or "(none)" are accepted for',
       "x, y, color, fill, size, shape, linetype, group, alpha.",
       "No expressions, no functions (e.g. mean(x) is invalid),",
@@ -20,7 +20,7 @@ register_ggplot_blocks <- function() {
       '\n\n"(none)" is the sentinel value for omitting an aesthetic.',
       "Do not use empty string, null, or NA.",
       '\n\nFor bar charts counting rows: set y = "(none)".',
-      '\n\nFor histogram: set y = "(none)" — counts are automatic.',
+      '\n\nFor histogram: set y = "(none)" -- counts are automatic.',
       "\n\nIf the user wants computed statistics (mean, median, sum, etc.),",
       "suggest adding an upstream Summarize/Aggregate block first,",
       "then plot the pre-computed column."
@@ -31,7 +31,7 @@ register_ggplot_blocks <- function() {
           paste0(
             'Plot type. Valid values: "point", "bar", "col", "line", ',
             '"histogram", "density", "boxplot", "violin", "pie". ',
-            'NOTE: "scatter" is NOT valid — use "point" for scatter plots.'
+            'NOTE: "scatter" is NOT valid -- use "point" for scatter plots.'
           ),
           example = "point",
           type = arg_enum(
@@ -95,7 +95,7 @@ register_ggplot_blocks <- function() {
           type = arg_number()
         ),
         position = new_block_arg(
-          '"stack", "dodge", or "fill" — position adjustment for bar/col/histogram',
+          '"stack", "dodge", or "fill" -- position adjustment for bar/col/histogram',
           example = "stack",
           type = arg_enum(c("stack", "dodge", "fill"))
         ),
@@ -126,7 +126,7 @@ register_ggplot_blocks <- function() {
     icon = "grid-3x3",
     guidance = paste(
       "This block arranges existing plot outputs into a grid layout.",
-      "It does NOT create plots — plots must come from upstream ggplot blocks.",
+      "It does NOT create plots -- plots must come from upstream ggplot blocks.",
       'Use guides = "collect" to de-duplicate shared legends across panels.'
     ),
     arguments = list(
@@ -340,12 +340,12 @@ register_ggplot_blocks <- function() {
           type = arg_enum(c("label_value", "label_both", "label_parsed"))
         ),
         dir = new_block_arg(
-          '"h" (horizontal) or "v" (vertical) — fill direction for wrap',
+          '"h" (horizontal) or "v" (vertical) -- fill direction for wrap',
           example = "h",
           type = arg_enum(c("h", "v"))
         ),
         space = new_block_arg(
-          '"fixed", "free_x", or "free_y" — panel sizing for grid',
+          '"fixed", "free_x", or "free_y" -- panel sizing for grid',
           example = "fixed",
           type = arg_enum(c("fixed", "free_x", "free_y"))
         )


### PR DESCRIPTION
Adopts blockr.core's formal block-argument registry (`new_block_args()` /
`new_block_arg()` / `arg_*()`) in place of the undocumented
`attr(arguments, "examples"/"prompt")` side-channel. Each declared
argument now binds its JSON-Schema type via `arg_*()`, and the old
per-block `prompt` is lifted into the vectorized `guidance=` argument of
`register_blocks()`.

Producer side of BristolMyersSquibb/blockr.ai#86. Requires blockr.core
`main` (the #121 API), already merged.

Verified locally: `pkgload::load_all()` passes the `register_blocks()`
example-conformance gate; own source carries no legacy attribute usage.
