### PR TITLE
Design-system alignment: amber required-empty fields, commit-on-Enter drilldown

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# blockr.ggplot (development version)
+
+## Improvements
+
+- Text inputs in the settings band (grid block title, subtitle, caption)
+  now commit on Enter or blur with an "Enter ↵" confirm chip instead of
+  auto-submitting on a 300ms debounce, following the design-system
+  text-commit convention (shared drilldown engine, re-vendored from
+  blockr.viz).
+- Design-token fallback fixes: slider accent and preview-status colors now
+  fall back to the canonical design-system values (`#2563eb` primary,
+  `#16a34a` success, `#b45309` warning text, `#dc2626` danger).
+
 # blockr.ggplot 0.1.0
 
 Initial CRAN release.

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,10 @@
 - Design-token fallback fixes: slider accent and preview-status colors now
   fall back to the canonical design-system values (`#2563eb` primary,
   `#16a34a` success, `#b45309` warning text, `#dc2626` danger).
+- The facet and grid blocks no longer show a yellow warning banner when
+  unconfigured: the facet "Facet by" field carries the amber
+  required-empty cue instead, and both previews show a quiet muted
+  one-line hint (design-system convention).
 
 # blockr.ggplot 0.1.0
 

--- a/R/facet-block.R
+++ b/R/facet-block.R
@@ -448,14 +448,12 @@ new_facet_block <- function(
             if (current_type == "wrap") {
               # Calculate number of unique levels for preview
               if (length(r_facets()) == 0) {
+                # Quiet hint only \u2014 the "Facet by" field itself carries the
+                # amber required-empty cue (engine requiredMap), per the
+                # design-system convention; no warning banner.
                 return(tags$div(
-                  style = paste(
-                    "padding: 10px; background: #fff3cd;",
-                    "border-radius: 4px; margin-bottom: 15px;"
-                  ),
-                  tags$strong("\u26a0\ufe0f Select facet variable(s)"),
-                  tags$br(),
-                  "Choose one or more columns to facet by"
+                  style = "font-size: 0.875rem; color: #6c757d;",
+                  "Select one or more columns to facet by"
                 ))
               }
 

--- a/R/facet-block.R
+++ b/R/facet-block.R
@@ -446,15 +446,12 @@ new_facet_block <- function(
             current_type <- r_facet_type()
 
             if (current_type == "wrap") {
-              # Calculate number of unique levels for preview
+              # Nothing to preview yet, and nothing to say: the "Facet by"
+              # field carries the amber required-empty cue and the help line
+              # beneath it (engine requiredMap + role hint). No banner, no
+              # duplicated instruction down here.
               if (length(r_facets()) == 0) {
-                # Quiet hint only \u2014 the "Facet by" field itself carries the
-                # amber required-empty cue (engine requiredMap), per the
-                # design-system convention; no warning banner.
-                return(tags$div(
-                  style = "font-size: 0.875rem; color: #6c757d;",
-                  "Select one or more columns to facet by"
-                ))
+                return(NULL)
               }
 
               # Use actual data to count unique levels
@@ -469,12 +466,10 @@ new_facet_block <- function(
                 dir = r_dir()
               )
             } else {
-              # facet_grid
+              # facet_grid: rows and cols are either-or, so neither field is
+              # marked required; their help lines carry the instruction.
               if (length(r_rows()) == 0 && length(r_cols()) == 0) {
-                return(tags$div(
-                  style = "font-size: 0.875rem; color: #6c757d;",
-                  "Select row and/or column variables"
-                ))
+                return(NULL)
               }
 
               # Use actual data to count unique levels

--- a/R/ggplot-dep.R
+++ b/R/ggplot-dep.R
@@ -25,7 +25,7 @@ ggplot_block_deps <- function() {
     ),
     htmltools::htmlDependency(
       name = "gg-blocks-js",
-      version = paste0(utils::packageVersion("blockr.ggplot"), ".6"),
+      version = paste0(utils::packageVersion("blockr.ggplot"), ".7"),
       src = system.file("js", package = "blockr.ggplot"),
       # drilldown-config.js (the shared gear/settings-band engine) must load
       # BEFORE gg-blocks.js, which references Blockr.DrilldownConfig.
@@ -33,7 +33,7 @@ ggplot_block_deps <- function() {
     ),
     htmltools::htmlDependency(
       name = "gg-blocks-css",
-      version = paste0(utils::packageVersion("blockr.ggplot"), ".6"),
+      version = paste0(utils::packageVersion("blockr.ggplot"), ".7"),
       src = system.file("css", package = "blockr.ggplot"),
       stylesheet = "gg-blocks.css"
     )

--- a/R/ggplot-dep.R
+++ b/R/ggplot-dep.R
@@ -25,7 +25,7 @@ ggplot_block_deps <- function() {
     ),
     htmltools::htmlDependency(
       name = "gg-blocks-js",
-      version = paste0(utils::packageVersion("blockr.ggplot"), ".8"),
+      version = paste0(utils::packageVersion("blockr.ggplot"), ".9"),
       src = system.file("js", package = "blockr.ggplot"),
       # drilldown-config.js (the shared gear/settings-band engine) must load
       # BEFORE gg-blocks.js, which references Blockr.DrilldownConfig.
@@ -33,7 +33,7 @@ ggplot_block_deps <- function() {
     ),
     htmltools::htmlDependency(
       name = "gg-blocks-css",
-      version = paste0(utils::packageVersion("blockr.ggplot"), ".8"),
+      version = paste0(utils::packageVersion("blockr.ggplot"), ".9"),
       src = system.file("css", package = "blockr.ggplot"),
       stylesheet = "gg-blocks.css"
     )

--- a/R/ggplot-dep.R
+++ b/R/ggplot-dep.R
@@ -26,7 +26,7 @@ ggplot_block_deps <- function() {
     ),
     htmltools::htmlDependency(
       name = "gg-blocks-js",
-      version = paste0(utils::packageVersion("blockr.ggplot"), ".9"),
+      version = paste0(utils::packageVersion("blockr.ggplot"), ".10"),
       src = system.file("js", package = "blockr.ggplot"),
       # drilldown-config.js (the shared gear/settings-band engine) must load
       # BEFORE gg-blocks.js, which references Blockr.DrilldownConfig.
@@ -34,7 +34,7 @@ ggplot_block_deps <- function() {
     ),
     htmltools::htmlDependency(
       name = "gg-blocks-css",
-      version = paste0(utils::packageVersion("blockr.ggplot"), ".9"),
+      version = paste0(utils::packageVersion("blockr.ggplot"), ".10"),
       src = system.file("css", package = "blockr.ggplot"),
       stylesheet = "gg-blocks.css"
     )

--- a/R/ggplot-dep.R
+++ b/R/ggplot-dep.R
@@ -25,7 +25,7 @@ ggplot_block_deps <- function() {
     ),
     htmltools::htmlDependency(
       name = "gg-blocks-js",
-      version = paste0(utils::packageVersion("blockr.ggplot"), ".7"),
+      version = paste0(utils::packageVersion("blockr.ggplot"), ".8"),
       src = system.file("js", package = "blockr.ggplot"),
       # drilldown-config.js (the shared gear/settings-band engine) must load
       # BEFORE gg-blocks.js, which references Blockr.DrilldownConfig.
@@ -33,7 +33,7 @@ ggplot_block_deps <- function() {
     ),
     htmltools::htmlDependency(
       name = "gg-blocks-css",
-      version = paste0(utils::packageVersion("blockr.ggplot"), ".7"),
+      version = paste0(utils::packageVersion("blockr.ggplot"), ".8"),
       src = system.file("css", package = "blockr.ggplot"),
       stylesheet = "gg-blocks.css"
     )

--- a/R/ggplot-dep.R
+++ b/R/ggplot-dep.R
@@ -18,7 +18,8 @@ ggplot_block_deps <- function() {
     blockr_select_dep(),
     htmltools::htmlDependency(
       name = "gg-settings-band",
-      version = utils::packageVersion("blockr.ggplot"),
+      # Bump the suffix on every settings-band.css/js edit (asset cache).
+      version = paste0(utils::packageVersion("blockr.ggplot"), ".1"),
       src = system.file(package = "blockr.ggplot"),
       script = "js/settings-band.js",
       stylesheet = "css/settings-band.css"

--- a/R/grid-block.R
+++ b/R/grid-block.R
@@ -308,16 +308,12 @@ new_grid_block <- function(
             ncol_val <- r_ncol()
             nrow_val <- r_nrow()
 
-            # Handle case where no plots are connected yet
+            # Handle case where no plots are connected yet \u2014 quiet muted
+            # hint, not a warning banner (design-system convention).
             if (n_plots == 0) {
               return(tags$div(
-                style = paste(
-                  "padding: 10px; background: #fff3cd;",
-                  "border-radius: 4px; margin-bottom: 15px;"
-                ),
-                tags$strong("\u26a0\ufe0f Waiting for input plots"),
-                tags$br(),
-                "Connect 1 or more ggplot blocks to create a grid"
+                style = "font-size: 0.875rem; color: #6c757d;",
+                "Connect one or more ggplot blocks to create a grid"
               ))
             }
 

--- a/inst/css/gg-blocks.css
+++ b/inst/css/gg-blocks.css
@@ -54,6 +54,19 @@
   box-sizing: border-box;
 }
 
+/* Text input + "Enter ↵" commit chip (design-system §5.5 confirm cycle). */
+.dd-text-wrap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+}
+
+.dd-text-wrap .blockr-popover-input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 /* Fallback native select (only when Blockr.Select is unavailable). */
 .dd-cfg-select {
   width: 100%;
@@ -218,7 +231,7 @@
 }
 .dd-slider {
   width: 100%;
-  accent-color: var(--blockr-color-primary, #0072B2);
+  accent-color: var(--blockr-color-primary, #2563eb);
   cursor: pointer;
 }
 .dd-slider-value {
@@ -427,13 +440,13 @@
   margin-bottom: 8px;
 }
 .preview-status {
-  font-size: var(--blockr-font-size-sm, 0.875rem);
-  color: var(--blockr-grey-500, #6c757d);
+  font-size: var(--blockr-font-size-sm, 0.8125rem);
+  color: var(--blockr-grey-500, #6b7280);
   text-align: center;
   padding: 6px 8px;
   border-radius: 4px;
-  background-color: var(--blockr-grey-50, #f8f9fa);
+  background-color: var(--blockr-grey-50, #f9fafb);
 }
-.preview-status.valid { color: var(--blockr-color-success, #28a745); }
-.preview-status.warning { color: var(--blockr-color-warning, #ffc107); }
-.preview-status.error { color: var(--blockr-color-danger, #dc3545); }
+.preview-status.valid { color: var(--blockr-color-success, #16a34a); }
+.preview-status.warning { color: var(--blockr-color-warning-text, #b45309); }
+.preview-status.error { color: var(--blockr-color-danger, #dc2626); }

--- a/inst/css/gg-blocks.css
+++ b/inst/css/gg-blocks.css
@@ -54,17 +54,27 @@
   box-sizing: border-box;
 }
 
-/* Text input + "Enter ↵" commit chip (design-system §5.5 confirm cycle). */
+/* Text input + "Enter ↵" commit chip (design-system §5.5 confirm cycle).
+   The chip overlays inside the field's right edge, matching the chips in
+   blockr.dplyr's rows and blockr.io's path input. */
 .dd-text-wrap {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: 6px;
   width: 100%;
 }
 
 .dd-text-wrap .blockr-popover-input {
   flex: 1 1 auto;
   min-width: 0;
+  padding-right: 78px;
+}
+
+.dd-text-wrap .blockr-expr-confirm {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 /* Fallback native select (only when Blockr.Select is unavailable). */

--- a/inst/css/settings-band.css
+++ b/inst/css/settings-band.css
@@ -20,7 +20,12 @@
   display: none;
   border: 1px solid var(--blockr-color-border, #e5e7eb);
   border-radius: 8px;
-  padding: 12px 14px 8px;
+  /* Symmetric-looking breathing room: the 8px bottom only ever read as
+     enough because row-built bands (summary table) put an 8px margin under
+     every row, including the last. Bands whose grid is a plain field row
+     (blockr.dplyr's) had the controls nearly touching the border. The band
+     now owns the bottom rhythm; the stray last-row margin is zeroed below. */
+  padding: 12px 14px 16px;
   margin-bottom: 10px;
   background: #fff;
   box-sizing: border-box;
@@ -83,6 +88,13 @@
 
 /* Field grid for hand-built (non-engine) bands, e.g. the summary-table
    block: the flex-wrap responsive idiom, same as .stb-grid / .dd-form-row. */
+/* Row-built bands set an inline margin under each row; the last one would
+   double up with the band's bottom padding (hence !important, which is the
+   only way to beat an inline style). */
+.blockr-settings__grid > :last-child {
+  margin-bottom: 0 !important;
+}
+
 .blockr-settings__grid {
   flex: 1 1 100%;
   display: flex;

--- a/inst/js/drilldown-config.js
+++ b/inst/js/drilldown-config.js
@@ -72,7 +72,12 @@
     // -- small helpers --------------------------------------------------------
     get _SECONDARY() { return this.h.secondary; }
     /** @param {*} v */
-    _hasVal(v) { return v !== null && v !== undefined && v !== '' && v !== '(none)'; }
+    // An empty multi-column selection ([]) counts as "no value": otherwise a
+    // required `columns` role never gets the amber required-empty cue.
+    _hasVal(v) {
+      if (Array.isArray(v)) return v.length > 0;
+      return v !== null && v !== undefined && v !== '' && v !== '(none)';
+    }
     _cols() { return this.h.columns() || []; }
     _cfg() { return this.h.config(); }
     /** @param {string} key */
@@ -174,7 +179,10 @@
       if (this._hasVal(value)) return '';
       const role = this._role(key);
       if (!role) return '';
-      return (role.hintBy && role.hintBy[this.h.context()]) || role.ph || '';
+      // `hint` is a context-independent help line; `hintBy` keys it by
+      // context; `ph` (the placeholder) is the last-resort fallback.
+      return (role.hintBy && role.hintBy[this.h.context()]) || role.hint ||
+        role.ph || '';
     }
 
     // -- render ---------------------------------------------------------------
@@ -613,7 +621,8 @@
           !this._hasVal(this._cfg()[key]));
       };
       const setHelp = () => {
-        if (role.kind !== 'column' || (reversed && !usesMetric())) {
+        const picker = role.kind === 'column' || role.kind === 'columns';
+        if (!picker || (reversed && !usesMetric())) {
           helpEl.style.display = 'none'; return;
         }
         const txt = this._fieldHelp(key, this._cfg()[key]);

--- a/inst/js/drilldown-config.js
+++ b/inst/js/drilldown-config.js
@@ -1068,19 +1068,61 @@
         // Canonical popover text input (blockr.dplyr blockr-blocks.css). Note:
         // no .dd-picker-wrap here — that wrapper carries its own border for the
         // borderless Blockr.Select; a bordered input inside it double-borders.
+        // Commit model (design-system §5.5): typing never mutates cfg — the
+        // value commits on Enter, blur or the "Enter ↵" chip, which then fades
+        // to ✓; Escape reverts to the last committed value.
         const inp = document.createElement('input');
         inp.type = 'text';
         inp.className = 'blockr-popover-input';
         inp.value = (cfg[key] == null) ? '' : String(cfg[key]);
         if (role.ph) inp.placeholder = role.ph;
-        /** @type {ReturnType<typeof setTimeout> | undefined} */
-        let deb;
-        inp.addEventListener('input', () => {
+        const wrap = document.createElement('div');
+        wrap.className = 'dd-text-wrap';
+        const chip = document.createElement('button');
+        chip.type = 'button';
+        chip.className = 'blockr-expr-confirm dd-text-commit';
+        chip.title = 'Apply (Enter)';
+        chip.setAttribute('aria-label', 'Apply (Enter)');
+        chip.style.display = 'none';
+        let committed = inp.value;
+        let everCommitted = false;
+        const confirmIcon = () =>
+          (typeof Blockr !== 'undefined' && Blockr.icons && Blockr.icons.confirm) ?
+            Blockr.icons.confirm : '✓';
+        const syncChip = () => {
+          if (inp.value !== committed) {
+            chip.style.display = '';
+            chip.classList.remove('confirmed');
+            chip.innerHTML = 'Enter <span class="blockr-kbd">↵</span>';
+          } else if (everCommitted) {
+            chip.style.display = '';
+            chip.classList.add('confirmed');
+            chip.innerHTML = confirmIcon();
+          } else {
+            chip.style.display = 'none';
+          }
+        };
+        const commit = () => {
+          if (inp.value === committed) return;
+          committed = inp.value;
+          everCommitted = true;
           cfg[key] = inp.value;
-          clearTimeout(deb);
-          deb = setTimeout(() => { cb(); this.h.onChange(key); }, 300);
+          cb();
+          this.h.onChange(key);
+          syncChip();
+        };
+        inp.addEventListener('input', syncChip);
+        inp.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter') { e.preventDefault(); commit(); }
+          else if (e.key === 'Escape') { inp.value = committed; syncChip(); }
         });
-        parent.appendChild(inp);
+        inp.addEventListener('blur', commit);
+        // Keep focus on the input so the chip click doesn't race blur-commit.
+        chip.addEventListener('mousedown', (e) => e.preventDefault());
+        chip.addEventListener('click', commit);
+        wrap.appendChild(inp);
+        wrap.appendChild(chip);
+        parent.appendChild(wrap);
       } else if (role.kind === 'slider') {
         this._buildSlider(parent, key);
       } else if (role.kind === 'color') {

--- a/inst/js/gg-blocks.js
+++ b/inst/js/gg-blocks.js
@@ -311,8 +311,11 @@
   /** @type {Record<string, { requiredMap: string[], optionalMap: string[], mapping: any[], presentation: any[] }>} */
   const FACET_TYPE_MAIN = {
     wrap: {
-      requiredMap: [], optionalMap: [],
-      mapping: ['facets'],
+      // facets is required-empty: facet_wrap with no variables is a
+      // pass-through, so the field gets the soft amber cue (the R-side
+      // preview keeps a muted one-line hint, no warning banner).
+      requiredMap: ['facets'], optionalMap: [],
+      mapping: [],
       presentation: ['ncol', 'nrow', 'scales']
     },
     grid: {

--- a/inst/js/gg-blocks.js
+++ b/inst/js/gg-blocks.js
@@ -259,9 +259,20 @@
 
   /** @type {Record<string, any>} */
   const FACET_ROLES = {
-    facets: { label: 'Facet by', kind: 'columns', placeholder: 'None' },
-    rows:   { label: 'Rows',     kind: 'columns', placeholder: 'None' },
-    cols:   { label: 'Columns',  kind: 'columns', placeholder: 'None' },
+    // Hints are terse noun phrases (the label already says what the field
+    // is), matching blockr.viz's "column to aggregate…" help lines.
+    facets: {
+      label: 'Facet by', kind: 'columns', placeholder: 'None',
+      hint: 'one or more columns'
+    },
+    rows:   {
+      label: 'Rows', kind: 'columns', placeholder: 'None',
+      hint: 'one or more columns'
+    },
+    cols:   {
+      label: 'Columns', kind: 'columns', placeholder: 'None',
+      hint: 'one or more columns'
+    },
     ncol: {
       label: 'Columns', kind: 'select', ph: 'Auto',
       options: [{ value: '', label: 'Auto' }, '1', '2', '3', '4', '5']


### PR DESCRIPTION
## Summary
- Facet/grid: amber required-empty field cue replaces yellow warning banners
- Re-vendor drilldown engine with commit-on-Enter text inputs; token fallback fixes
- Re-vendor `settings-band.css` (band owns its own bottom padding)
- Sync `.dd-text-wrap` from blockr.viz (chip inside the field)

Part of the ongoing blockr.design rollout across dplyr/io/ggplot.