### PR TITLE
Drop the facet help lines, prompt on the required pickers

### DIFF
--- a/R/facet-block.R
+++ b/R/facet-block.R
@@ -447,9 +447,8 @@ new_facet_block <- function(
 
             if (current_type == "wrap") {
               # Nothing to preview yet, and nothing to say: the "Facet by"
-              # field carries the amber required-empty cue and the help line
-              # beneath it (engine requiredMap + role hint). No banner, no
-              # duplicated instruction down here.
+              # field carries the amber required-empty cue (engine
+              # requiredMap). No banner, no duplicated instruction down here.
               if (length(r_facets()) == 0) {
                 return(NULL)
               }

--- a/inst/js/drilldown-config.js
+++ b/inst/js/drilldown-config.js
@@ -1,4 +1,7 @@
 /**
+ * CANONICAL SOURCE: blockr.viz/inst/js/drilldown-config.js
+ * Vendored verbatim into blockr.ggplot/inst/js/. Edit here, then copy across.
+ *
  * DrilldownConfig — the shared gear-popover config engine for blockr drilldown
  * blocks (chart, table, …). Host-agnostic: it renders a grouped, role-spec
  * driven popover (Mapping / Presentation + a Drill-down section) and calls
@@ -170,19 +173,22 @@
       return typeof e === 'string' || !e.types || e.types.includes(this.h.currentType());
     }
 
-    /** @param {string} key @param {*} value */
-    _fieldHelp(key, value) {
-      // Filled fields get no help line: the select's value display already
-      // shows `name  label` (labels-everywhere, blockr-select.js
-      // fillOptContent), so echoing `name (label)` here would duplicate it.
-      // The help line only surfaces the role hint while the field is empty.
-      if (this._hasVal(value)) return '';
+    /**
+     * A help line speaks about the field's VALUE, so it renders whatever the
+     * value is, empty or not. It must never restate the placeholder, which
+     * speaks about the empty slot and disappears on fill, nor the label, which
+     * names the field. See blockr.docs design-system/ux-principles.md.
+     *
+     * There is deliberately no `role.ph` fallback: echoing the placeholder
+     * beneath its own control printed the same string twice.
+     *
+     * @param {string} key
+     */
+    _fieldHelp(key) {
       const role = this._role(key);
       if (!role) return '';
-      // `hint` is a context-independent help line; `hintBy` keys it by
-      // context; `ph` (the placeholder) is the last-resort fallback.
-      return (role.hintBy && role.hintBy[this.h.context()]) || role.hint ||
-        role.ph || '';
+      // `hint` is a context-independent help line; `hintBy` keys it by context.
+      return (role.hintBy && role.hintBy[this.h.context()]) || role.hint || '';
     }
 
     // -- render ---------------------------------------------------------------
@@ -625,7 +631,7 @@
         if (!picker || (reversed && !usesMetric())) {
           helpEl.style.display = 'none'; return;
         }
-        const txt = this._fieldHelp(key, this._cfg()[key]);
+        const txt = this._fieldHelp(key);
         helpEl.textContent = txt;
         helpEl.style.display = txt ? '' : 'none';
       };
@@ -1185,9 +1191,11 @@
      */
     _mkSelect(wrap, opts, selected, onSel, key, decorate) {
       if (typeof Blockr !== 'undefined' && Blockr.Select) {
-        // role.ph doubles as the select placeholder so ''-valued options
-        // ("Auto", "None") don't render an empty control.
-        const ph = (this._role(key) || {}).ph;
+        // The placeholder speaks for the empty slot: on an optional field it
+        // names what empty does ("Auto", "None"), on a required one it says
+        // what to supply. `phBy` keys it by context, like colTypeBy.
+        const role = this._role(key) || {};
+        const ph = (role.phBy && role.phBy[this.h.context()]) || role.ph;
         this._selects[key] = Blockr.Select.single(wrap, { options: opts, selected, placeholder: ph, onChange: onSel });
       } else {
         const s = document.createElement('select');

--- a/inst/js/gg-blocks.js
+++ b/inst/js/gg-blocks.js
@@ -23,8 +23,13 @@
   // Shiny selects, which offered every column; the R expression wraps
   // shape/linetype/discrete-fill in as.factor() where needed).
   const GG_ROLES = {
-    x:        { label: 'X-axis',       kind: 'column', colType: 'any' },
-    y:        { label: 'Y-axis',       kind: 'column', colType: 'any' },
+    // x/y are required, so empty is not a configuration to name: the
+    // placeholder says what to supply. The optional roles below are never
+    // blank — they carry a `(none)` option which displays when unset.
+    x:        { label: 'X-axis',       kind: 'column', colType: 'any',
+                ph: 'Select column…' },
+    y:        { label: 'Y-axis',       kind: 'column', colType: 'any',
+                ph: 'Select column…' },
     color:    { label: 'Color by',     kind: 'column', colType: 'any' },
     fill:     { label: 'Fill by',      kind: 'column', colType: 'any' },
     size:     { label: 'Size by',      kind: 'column', colType: 'any' },
@@ -259,20 +264,12 @@
 
   /** @type {Record<string, any>} */
   const FACET_ROLES = {
-    // Hints are terse noun phrases (the label already says what the field
-    // is), matching blockr.viz's "column to aggregate…" help lines.
-    facets: {
-      label: 'Facet by', kind: 'columns', placeholder: 'None',
-      hint: 'one or more columns'
-    },
-    rows:   {
-      label: 'Rows', kind: 'columns', placeholder: 'None',
-      hint: 'one or more columns'
-    },
-    cols:   {
-      label: 'Columns', kind: 'columns', placeholder: 'None',
-      hint: 'one or more columns'
-    },
+    // No `hint`: the label names the field and the picker lists the columns,
+    // so a help line here would only restate them (design-system ux-principles,
+    // "Help text earns its place").
+    facets: { label: 'Facet by', kind: 'columns', placeholder: 'None' },
+    rows:   { label: 'Rows', kind: 'columns', placeholder: 'None' },
+    cols:   { label: 'Columns', kind: 'columns', placeholder: 'None' },
     ncol: {
       label: 'Columns', kind: 'select', ph: 'Auto',
       options: [{ value: '', label: 'Auto' }, '1', '2', '3', '4', '5']


### PR DESCRIPTION
## Summary
- Vendored `drilldown-config.js` update from blockr.viz: `_fieldHelp` now renders for filled fields too (speaks about the value, not just the empty slot) and drops the `role.ph` fallback that duplicated the placeholder
- `_mkSelect` placeholder resolution now supports `phBy` (per-context placeholder), mirroring `colTypeBy`
- Facet block: `x`/`y` (required) get an explicit `ph: 'Select column…'`; facet roles (`facets`/`rows`/`cols`) drop their redundant `hint` now that the label + picker already say what's needed