### PR TITLE
Re-vendor drilldown-config.js: facet pickers are drag-reorderable, enforce JS typecheck in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,3 +35,14 @@ jobs:
     secrets: inherit
     permissions:
       contents: write
+
+  # Type-check the hand-written JS in inst/js (tsconfig.json; opt-in
+  # per file via // @ts-check). No build step — checking only.
+  typecheck-js:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npx -y -p typescript@~6.0.0 tsc

--- a/R/ggplot-dep.R
+++ b/R/ggplot-dep.R
@@ -26,7 +26,7 @@ ggplot_block_deps <- function() {
     ),
     htmltools::htmlDependency(
       name = "gg-blocks-js",
-      version = paste0(utils::packageVersion("blockr.ggplot"), ".10"),
+      version = paste0(utils::packageVersion("blockr.ggplot"), ".11"),
       src = system.file("js", package = "blockr.ggplot"),
       # drilldown-config.js (the shared gear/settings-band engine) must load
       # BEFORE gg-blocks.js, which references Blockr.DrilldownConfig.

--- a/inst/js/drilldown-config.js
+++ b/inst/js/drilldown-config.js
@@ -786,7 +786,7 @@
             ? 'All numeric columns' : 'column(s)…';
           if (S && S.multi) {
             S.multi(colsWrap, {
-              options: opts, selected: (m.cols || []).slice(), reorderable: false,
+              options: opts, selected: (m.cols || []).slice(),
               placeholder: ph,
               onChange: (/** @type {string[]} */ vals) => { m.cols = vals; commit(); }
             });
@@ -875,7 +875,7 @@
         if (S && S.multi) {
           S.multi(colsWrap, {
             options: this._colOptsByType('num'),
-            selected: (s.cols || []).slice(), reorderable: false,
+            selected: (s.cols || []).slice(),
             placeholder: 'All numeric columns',
             onChange: (/** @type {string[]} */ vals) => { s.cols = vals; commit(); }
           });
@@ -1026,6 +1026,10 @@
         // Multi-column scope picker. Wires the existing Blockr.Select.multi
         // primitive; empty selection is meaningful (= "all", per the host's
         // placeholder), so there is no '(none)' option. Value is an array.
+        // Pick order is semantic for every consumer of this role -- the
+        // table's group keys nest and lead the output columns, the chart's
+        // tooltip fields print in order, ggplot's facet vars order the
+        // panels -- so the chips stay drag-reorderable (the default).
         const opts = this._colOptionsFor(key, { required: true });
         const sel = Array.isArray(cfg[key]) ? cfg[key].slice() : [];
         const wrap = document.createElement('div');
@@ -1040,7 +1044,7 @@
         };
         if (typeof Blockr !== 'undefined' && Blockr.Select && Blockr.Select.multi) {
           this._selects[key] = Blockr.Select.multi(wrap, {
-            options: opts, selected: sel, reorderable: false,
+            options: opts, selected: sel,
             placeholder: role.placeholder || 'All', onChange: onSel
           });
         } else {

--- a/inst/js/drilldown-config.js
+++ b/inst/js/drilldown-config.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * CANONICAL SOURCE: blockr.viz/inst/js/drilldown-config.js
  * Vendored verbatim into blockr.ggplot/inst/js/. Edit here, then copy across.


### PR DESCRIPTION
## Summary
- Re-vendor drilldown-config.js so facet pickers support drag-reorder.
- Enforce the JS typecheck in CI, and check drilldown-config.js.