### PR TITLE
perf: memoise htmlDependency builder

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blockr.ggplot
 Title: Interactive 'ggplot2' Visualization Blocks
-Version: 0.1.1.9000
+Version: 0.1.1.9001
 Authors@R:
     c(person(given = "Christoph",
              family = "Sax",

--- a/R/aaa-memoise.R
+++ b/R/aaa-memoise.R
@@ -1,0 +1,24 @@
+# aaa- prefix so it collates first: the *_dep() builders below call memoise0()
+# at package-load time to build their wrappers, so it must already be defined.
+
+#' Run a nullary builder at most once per process, caching the result in a
+#' private environment. Base-R memoise (no dependency, no `<<-`): the closure
+#' captures a mutable env and mutates it in place, so nothing rebinds an
+#' enclosing frame. The `exists()` guard (not `is.null`) caches a genuine `NULL`
+#' result too.
+#'
+#' Used for the block htmlDependency builders: each takes no data-dependent args
+#' and returns the same immutable object for the life of the process, yet was
+#' re-running disk I/O (packageVersion -> read.dcf + system.file) on every block
+#' construction/render. htmlDependency objects are immutable value lists
+#' htmltools already shares across sessions, so one cached copy per process
+#' shared across Shiny sessions is correct. Mirrors blockr.viz / blockr.dplyr.
+#' @noRd
+memoise0 <- function(build) {
+  force(build)
+  cache <- new.env(parent = emptyenv())
+  function() {
+    if (!exists("v", cache, inherits = FALSE)) cache$v <- build()
+    cache$v
+  }
+}

--- a/R/ggplot-dep.R
+++ b/R/ggplot-dep.R
@@ -12,7 +12,7 @@
 #'
 #' @importFrom blockr.dplyr blockr_blocks_css_dep blockr_select_dep
 #' @noRd
-ggplot_block_deps <- function() {
+ggplot_block_deps <- memoise0(function() {
   htmltools::tagList(
     blockr_blocks_css_dep(),
     blockr_select_dep(),
@@ -39,4 +39,4 @@ ggplot_block_deps <- function() {
       stylesheet = "gg-blocks.css"
     )
   )
-}
+})


### PR DESCRIPTION
## Summary
- Memoise the package's htmlDependency builder via a shared base-R closure (`memoise0` in `R/aaa-memoise.R`), avoiding a `memoise` package dependency
- Rebuilding the same dependency object repeatedly (e.g. once per block render) was unnecessary overhead; this caches by construction

## Test plan
- [ ] CI (R CMD check / lint) green