### PR TITLE
Drop the backtick helpers, obsoleted by AST construction

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,33 +1,3 @@
-#' Check if names need backticks for ggplot operations (vectorized)
-#'
-#' @param names Character vector of names to check
-#' @return Logical vector indicating if backticks are needed
-#' @noRd
-#' @examples
-#' needs_backticks(c("normal_name", "2025 Sales", "Product-Name"))
-#' # Returns: c(FALSE, TRUE, TRUE)
-needs_backticks <- function(names) {
-  # Check which names are non-syntactic
-  needs_bt <- make.names(names) != names
-  # Empty or NA names don't need backticks (handled separately)
-  needs_bt[is.na(names) | names == ""] <- FALSE
-  needs_bt
-}
-
-#' Wrap names in backticks if needed (vectorized)
-#'
-#' @param names Character vector of names to potentially wrap
-#' @return Character vector with non-syntactic names wrapped in backticks
-#' @noRd
-#' @examples
-#' backtick_if_needed(c("normal_name", "2025 Sales", "Product-Name"))
-#' # Returns: c("normal_name", "`2025 Sales`", "`Product-Name`")
-backtick_if_needed <- function(names) {
-  needs_bt <- needs_backticks(names)
-  names[needs_bt] <- sprintf("`%s`", names[needs_bt])
-  names
-}
-
 #' Fold ggplot layers into a `a + b + c` chain
 #'
 #' Combine a list of language objects into a single left-associative `+`

--- a/tests/testthat/test-nonsyntactic-names.R
+++ b/tests/testthat/test-nonsyntactic-names.R
@@ -1,58 +1,10 @@
 # Tests for non-syntactic column names (backtick handling)
 # See: https://github.com/BristolMyersSquibb/blockr.ggplot/issues/69
 
-# =============================================================================
-# Utility function tests
-# =============================================================================
-
-test_that("needs_backticks correctly identifies non-syntactic names", {
-  # Standard R names don't need backticks
-
-  expect_false(needs_backticks("normal_name"))
-  expect_false(needs_backticks("x"))
-  expect_false(needs_backticks("my.var"))
-
-
-  # Names starting with numbers need backticks
-  expect_true(needs_backticks("2025"))
-  expect_true(needs_backticks("2025 Sales"))
-  expect_true(needs_backticks("123abc"))
-
-  # Names with spaces need backticks
-
-  expect_true(needs_backticks("Product Category"))
-  expect_true(needs_backticks("First Name"))
-
-  # Names with special characters need backticks
-  expect_true(needs_backticks("col-name"))
-  expect_true(needs_backticks("col/name"))
-  expect_true(needs_backticks("col@name"))
-
-  # Empty and NA don't need backticks
-  expect_false(needs_backticks(""))
-  expect_false(needs_backticks(NA_character_))
-})
-
-test_that("needs_backticks works with vectors", {
-  result <- needs_backticks(c("normal", "2025 Sales", "col-name", "", NA))
-  expect_equal(result, c(FALSE, TRUE, TRUE, FALSE, FALSE))
-})
-
-test_that("backtick_if_needed wraps non-syntactic names", {
-  # Standard names unchanged
-  expect_equal(backtick_if_needed("normal_name"), "normal_name")
-  expect_equal(backtick_if_needed("x"), "x")
-
-  # Non-syntactic names get backticks
-  expect_equal(backtick_if_needed("2025 Sales"), "`2025 Sales`")
-  expect_equal(backtick_if_needed("Product Category"), "`Product Category`")
-  expect_equal(backtick_if_needed("col-name"), "`col-name`")
-})
-
-test_that("backtick_if_needed works with vectors", {
-  result <- backtick_if_needed(c("normal", "2025 Sales", "col-name"))
-  expect_equal(result, c("normal", "`2025 Sales`", "`col-name`"))
-})
+# Blocks build their expressions as language objects, so `as.name()` carries a
+# non-syntactic name through without any quoting step; there is no string for
+# the parser to misread. These tests drive the real blocks end to end to
+# confirm that. `test-expr-golden.R` locks the emitted code itself.
 
 # =============================================================================
 # ggplot block tests with non-syntactic column names
@@ -150,20 +102,13 @@ test_that("ggplot with non-syntactic fill column - testServer", {
 })
 
 # =============================================================================
-# Direct facet code tests (evaluating expression directly)
+# facet block tests with non-syntactic column names
 # =============================================================================
 
-test_that("facet_wrap formula with non-syntactic column is valid", {
+test_that("facet_wrap works with a non-syntactic column - testServer", {
+  skip_if_not_installed("shiny")
   skip_if_not_installed("ggplot2")
 
-  # Test that backtick_if_needed produces valid facet formulas
-  facet_var <- "Year Group"
-  facet_formula_str <- paste0("~", backtick_if_needed(facet_var))
-
-  # This should create a valid formula
-  expect_equal(facet_formula_str, "~`Year Group`")
-
-  # Verify ggplot2 can parse this
   test_data <- data.frame(
     x = 1:10,
     y = rnorm(10),
@@ -171,34 +116,28 @@ test_that("facet_wrap formula with non-syntactic column is valid", {
     check.names = FALSE
   )
 
-  p <- ggplot2::ggplot(test_data, ggplot2::aes(x = x, y = y)) +
+  plot <- ggplot2::ggplot(test_data, ggplot2::aes(x = x, y = y)) +
     ggplot2::geom_point()
 
-  # Evaluate the facet expression directly
-  facet_expr <- parse(text = sprintf(
-    "p + ggplot2::facet_wrap(%s)",
-    facet_formula_str
-  ))[[1]]
+  block <- new_facet_block(facet_type = "wrap", facets = "Year Group")
 
-  result <- eval(facet_expr)
-  expect_true(inherits(result, "ggplot"))
-  expect_true(inherits(result$facet, "FacetWrap"))
-  expect_no_error(ggplot2::ggplot_build(result))
+  testServer(
+    blockr.core:::get_s3_method("block_server", block),
+    {
+      session$flushReact()
+      result <- session$returned$result()
+
+      expect_true(inherits(result, "ggplot"))
+      expect_true(inherits(result$facet, "FacetWrap"))
+      expect_no_error(ggplot2::ggplot_build(result))
+    },
+    args = list(x = block, data = list(data = function() plot))
+  )
 })
 
-test_that("facet_grid formula with non-syntactic columns is valid", {
+test_that("facet_grid works with non-syntactic columns - testServer", {
+  skip_if_not_installed("shiny")
   skip_if_not_installed("ggplot2")
-
-  # Test row and column variables with non-syntactic names
-  row_var <- "Row Var"
-  col_var <- "Col Var"
-  grid_formula_str <- paste0(
-    backtick_if_needed(row_var),
-    " ~ ",
-    backtick_if_needed(col_var)
-  )
-
-  expect_equal(grid_formula_str, "`Row Var` ~ `Col Var`")
 
   test_data <- data.frame(
     x = 1:12,
@@ -208,17 +147,25 @@ test_that("facet_grid formula with non-syntactic columns is valid", {
     check.names = FALSE
   )
 
-  p <- ggplot2::ggplot(test_data, ggplot2::aes(x = x, y = y)) +
+  plot <- ggplot2::ggplot(test_data, ggplot2::aes(x = x, y = y)) +
     ggplot2::geom_point()
 
-  # Evaluate the facet expression directly
-  facet_expr <- parse(text = sprintf(
-    "p + ggplot2::facet_grid(%s)",
-    grid_formula_str
-  ))[[1]]
+  block <- new_facet_block(
+    facet_type = "grid",
+    rows = "Row Var",
+    cols = "Col Var"
+  )
 
-  result <- eval(facet_expr)
-  expect_true(inherits(result, "ggplot"))
-  expect_true(inherits(result$facet, "FacetGrid"))
-  expect_no_error(ggplot2::ggplot_build(result))
+  testServer(
+    blockr.core:::get_s3_method("block_server", block),
+    {
+      session$flushReact()
+      result <- session$returned$result()
+
+      expect_true(inherits(result, "ggplot"))
+      expect_true(inherits(result$facet, "FacetGrid"))
+      expect_no_error(ggplot2::ggplot_build(result))
+    },
+    args = list(x = block, data = list(data = function() plot))
+  )
 })


### PR DESCRIPTION
Follow-up to #92.

`needs_backticks()` / `backtick_if_needed()` existed so column names pasted into a `glue()`d string survived the round trip through `parse()`: a column called `2025 Sales` would otherwise produce the syntax error `x = 2025 Sales`. Since #92 the blocks build language objects directly, so `as.name()` carries any name through untouched and `deparse()` re-adds the backticks when printing. Nothing in `R/` has called either helper since.

## Changes

- Remove both helpers from `R/utils.R`.
- Remove their unit tests from `test-nonsyntactic-names.R`.
- **Replace** the two facet tests that asserted on hand-assembled formula *strings* — a construction the facet block no longer performs — with `testServer` tests driving the real block.

That last one is a net gain rather than a deletion: the facet block previously had **no** test that evaluated its result at all (`test-expr-golden.R` deparses the expression but never runs it). The new tests build a real ggplot, feed it through `new_facet_block()` with non-syntactic column names, and assert the result is a `FacetWrap`/`FacetGrid` that survives `ggplot_build()`.

The three `testServer` tests covering the ggplot block are untouched.

## Checks

- `devtools::test()` — 0 failures, 346 passing (`test-nonsyntactic-names.R` itself: 12 passing, up from 10 real block assertions)
- `devtools::check()` — 0 errors, 0 warnings, 1 pre-existing NOTE (unused `htmltools` import)
- `lintr::lint_package()` — clean